### PR TITLE
Edit faq_Putty_WinScp_2

### DIFF
--- a/docs/faq/faq_software.md
+++ b/docs/faq/faq_software.md
@@ -46,8 +46,8 @@ export PATH
 
 ホームページではWindowsに標準搭載されているPowerShellをターミナルエミュレータとして使った場合の利用手順を記載しています。
 
-- [&#x1f517;<u>SSH公開鍵の登録・変更</u>](/application/ssh_keys)
-- [&#x1f517;<u>SSH公開鍵の登録(Windowsの場合)</u>](/application/ssh_keys_windows)
+- [<u>SSH公開鍵の登録・変更</u>](/application/ssh_keys)
+- [<u>SSH公開鍵の登録(Windowsの場合)</u>](/application/ssh_keys_windows)
 
 サードパーティ製のターミナルエミュレータ(PuttyやTeraTerm等)を利用したい場合は、PowerShellの場合の利用方法をご参考の上、各ソフトウェアのマニュアルをご参照ください。
 
@@ -63,9 +63,9 @@ export PATH
 
 ホームページではscp, sftpコマンドを用いたファイル転送の手順を記載しています。
 
-- [&#x1f517;<u>データ転送(一般解析区画)</u>](/general_analysis_division/ga_transfer/)
+- [<u>データ転送(一般解析区画)</u>](/general_analysis_division/ga_transfer/)
 
-サードパーティ製のソフトウェア(WinScpやFileZilla等)を利用したい場合は、[&#x1f517;<u>データ転送(一般解析区画)</u>](/general_analysis_division/ga_transfer/)をご参考の上、各ソフトウェアのマニュアルをご参照ください。
+サードパーティ製のソフトウェア(WinScpやFileZilla等)を利用したい場合は、[<u>データ転送(一般解析区画)</u>](/general_analysis_division/ga_transfer/)をご参考の上、各ソフトウェアのマニュアルをご参照ください。
 
 - WinScp : 
 [&#x1f517;<u>WinSCP :: Official Site :: Free SFTP and FTP client for Windows</u>](https://winscp.net/eng/index.php)

--- a/i18n/en/docusaurus-plugin-content-docs/current/faq/faq_software.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/faq/faq_software.md
@@ -47,8 +47,8 @@ export PATH
 
 The NIG supercomputer website describes the procedure for using PowerShell, which comes standard with Windows, as a terminal emulator. 
 
-- [&#x1f517;<u>Registering or changing SSH public keys</u>](/application/ssh_keys)
-- [&#x1f517;<u>Registering or changing SSH public keys (Windows)</u>](/application/ssh_keys_windows)
+- [<u>Registering or changing SSH public keys</u>](/application/ssh_keys)
+- [<u>Registering or changing SSH public keys (Windows)</u>](/application/ssh_keys_windows)
 
 If you want to use a third-party terminal emulator (Putty, TeraTerm, etc.), refer to the manual of each software after referring to the instructions for using PowerShell.
 
@@ -64,9 +64,9 @@ If you want to use a third-party terminal emulator (Putty, TeraTerm, etc.), refe
 
 The NIG supercomputer website describes the procedure for transferring files using the scp and sftp commands.
 
-- [&#x1f517;<u>Data file transfer (The general analysis section)</u>](/general_analysis_division/ga_transfer/)
+- [<u>Data file transfer (The general analysis section)</u>](/general_analysis_division/ga_transfer/)
 
-If you want to use third-party software (e.g. WinScp or FileZilla), refer to the manual of each software after referring to the [&#x1f517;<u>Data file transfer (The general analysis section)</u>](/general_analysis_division/ga_transfer/) page.
+If you want to use third-party software (e.g. WinScp or FileZilla), refer to the manual of each software after referring to the [<u>Data file transfer (The general analysis section)</u>](/general_analysis_division/ga_transfer/) page.
 
 - WinScp : 
 [&#x1f517;<u>WinSCP :: Official Site :: Free SFTP and FTP client for Windows</u>](https://winscp.net/eng/index.php)


### PR DESCRIPTION
FAQの記載内容を修正いたしました下記につきまして、スパコンホームページのURLに外部リンクマークを付けてしまったことに気づかずプルリクエストしてしまいました。
外部リンクマークを削除いたしましたので、再度マージしていただけますでしょうか。

・PutteyやTeratermなど
・WinScpやFileZillaなど


お手数をお掛けして申し訳ございませんが、どうぞよろしくお願いいたします。