### PR TITLE
Edit blog_Lutre6 FIN

### DIFF
--- a/blog/2022-11-24-Lustre6_maintenance.md
+++ b/blog/2022-11-24-Lustre6_maintenance.md
@@ -1,6 +1,6 @@
 ---
 slug: 2022-11-24-Lustre6_maintenance
-title: "2022年11月24日(木) Lustre6の緊急メンテナンス"
+title: "(終了) 2022年11月24日(木) Lustre6の緊急メンテナンス"
 tags:
   - maintenance
 authros:

--- a/i18n/en/docusaurus-plugin-content-blog/2022-11-24-Lustre6_maintenance.md
+++ b/i18n/en/docusaurus-plugin-content-blog/2022-11-24-Lustre6_maintenance.md
@@ -1,6 +1,6 @@
 ---
 slug: 2022-11-24-Lustre6_maintenance
-title: "November 24, 2022: Emergency maintenance of Lustre6"
+title: "(Ended) November 24, 2022: Emergency maintenance of Lustre6"
 tags:
   - maintenance
 authros:


### PR DESCRIPTION
「2022年11月24日(木) Luntre6の緊急メンテナンス」に "(終了)" を追記いたしました。

https://sc.ddbj.nig.ac.jp/blog/2022-11-24-Lustre6_maintenance

どうぞよろしくお願いいたします。