### PR TITLE
Edit hardware.md high-speed storage list

### DIFF
--- a/docs/guides/hardware.md
+++ b/docs/guides/hardware.md
@@ -276,6 +276,7 @@ HPE Superdome Flex
 | /lustre6     | 3.8PB    | DDBJ 業務(旧システム)                       | 35GB/sec   | DDN SFA14KXE+SS8462, DDN 1U server, DDN SFA7700X |
 | /lustre7     | 8.0PB    | 一般解析区画のホーム領域       | 35GB/sec 以上 | DDN SFA14KXE+SS9012, DDN 1U server, DDN SFA7700X |
 | /lustre8     | 5.3PB    | 個人ゲノム解析区画のホーム領域 | 35GB/sec 以上 | DDN SFA14KXE+SS9012, DDN 1U server, DDN SFA7700X |
+| /lustre9     | 40PB    | DDBJ 業務(新システム) | 100GB/sec 以上 | DDN ES400NVX2+SS9024, DDN 1U server |
 
 
 ### DB用ストレージ

--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/hardware.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/hardware.md
@@ -270,10 +270,10 @@ HPE Superdome Flex
 
 | access path | Effective Capacity | Usage                                      | Peak Performance | Configuration  
 |-------------|--------------------|--------------------------------------------|------------------|--------------------------------------------------|
-| /lustre6    | 3.8PB              | DDBJ work                                  | 35GB/sec         | DDN SFA14KXE+SS8462, DDN 1U server, DDN SFA7700X |
+| /lustre6    | 3.8PB              | DDBJ work (The old system)                                  | 35GB/sec         | DDN SFA14KXE+SS8462, DDN 1U server, DDN SFA7700X |
 | /lustre7    | 8.0PB              | Home area of general analysis area         | 35GB/sec or more | DDN SFA14KXE+SS9012, DDN 1U server, DDN SFA7700X |
-| /lustre     | 5.3PB              | Home area of personal genome analysis area | 35GB/sec or more | DDN SFA14KXE+SS9012, DDN 1U server, DDN SFA7700X |
-
+| /lustre8     | 5.3PB              | Home area of personal genome analysis area | 35GB/sec or more | DDN SFA14KXE+SS9012, DDN 1U server, DDN SFA7700X |
+| /lustre9    | 40PB              | DDBJ work (The new system)                                  | 100GB/sec         | DDN ES400NVX2+SS9024, DDN 1U server |
 
 
 ### Large archive storage


### PR DESCRIPTION
ハードウェアのページで、高速ストレージの一覧表に、Lustre9を追記いたしました。
追記したところは、以下画像の赤丸部分です。

https://sc.ddbj.nig.ac.jp/guides/hardware#%E9%AB%98%E9%80%9F%E3%82%B9%E3%83%88%E3%83%AC%E3%83%BC%E3%82%B8-lustre-%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%82%B7%E3%82%B9%E3%83%86%E3%83%A0

<img width="744" alt="image" src="https://user-images.githubusercontent.com/56281391/233875501-e1a4a171-d37e-49fc-9f0a-490ef23fdbca.png">

どうぞよろしくお願いいたします。