### PR TITLE
Edit top and advanced_guides

### DIFF
--- a/blog/2023-06-05-network.md
+++ b/blog/2023-06-05-network.md
@@ -1,6 +1,6 @@
 ---
 slug: 2023-06-05-network
-title: "2023年6月5日(月) SINET6の機器メンテナンス作業による通信断のお知らせ"
+title: "(終了) 2023年6月5日(月) SINET6の機器メンテナンス作業による通信断のお知らせ"
 tags:
   - maintenance
 authros:

--- a/docs/advanced_guides/advanced_guide.md
+++ b/docs/advanced_guides/advanced_guide.md
@@ -63,6 +63,8 @@ https://github.com/NCGM-genome/WGSpipeline
 
 ## Archaea tools(旧 HCPtools)
 
+2023.01.10
+
 2022 年 10 月、HCPtools ソフトウェア提供元が、データ転送系のブランド名称として、「Bytix(バイティックス)」というブランド名を立ち上げ、製品名称が「HCPtools」から「Archaea tools」へ変更になりました。
 
 変更についての詳細は、[&#x1f517;<u>Bytix 公式ページ「製品名称変更等について」のページをご参照ください</u>](https://support.bytix.tech/important/)。

--- a/docs/guides/top.md
+++ b/docs/guides/top.md
@@ -20,11 +20,12 @@ sidebar_label: トップページ
 
 ## 最近のお知らせ
 
+- [国立国際医療研究センター　河合洋介副プロジェクト長より、ヒト全ゲノム解析の公共データの再解析データセットが公開されました](/advanced_guides/advanced_guide#%E3%83%92%E3%83%88%E5%85%A8%E3%82%B2%E3%83%8E%E3%83%A0%E8%A7%A3%E6%9E%90%E3%81%AE%E5%85%AC%E5%85%B1%E3%83%87%E3%83%BC%E3%82%BF%E3%81%AE%E5%86%8D%E8%A7%A3%E6%9E%90%E3%83%87%E3%83%BC%E3%82%BF%E3%82%BB%E3%83%83%E3%83%88) (2023.06.05)
 - [データベース用新ストレージシステムの稼働開始に伴い、一部のユーザの方は、データ移行をお願いいたします](/blog/2023-04-21-data_migration) (2023.04.21)
 - &#x26A0; [今年度(2022 年度)の年度末アカウント継続申請の受付期限を延長しました](/blog/2023-03-23-renewal-date-extended) (2023.03.23)
 - [誓約書へのサインが押印からAdobe社の電子サインになりました](/blog/2023-03-14-adobe_sign) (2023.03.14)
 - [Github Discussionsを開設しました](/blog/2023-02-08-news_GithubDiscussions) (2023.02.08)
-- [(株)クレアリンクテクノロジーが開発したBytix Archaea (旧HCPtools)の公式サポートサイトが公開されました](/advanced_guides/advanced_guide#archaea-tools旧hcptools) (2023.01.10)
+- [(株)クレアリンクテクノロジーが開発したBytix Archaea (旧HCPtools)の公式サポートサイトが公開されました](/advanced_guides/advanced_guide#archaea-tools%E6%97%A7-hcptools) (2023.01.10)
 - &#x1F9EC; [(株)ゲノムアナリティクスジャパンが開発したインピュテーションサーバの紹介ページを追加しました](/advanced_guides/advanced_guide#nbdc-ddbj-imputation-server-beta) (2022.10.18)
 
 

--- a/i18n/en/docusaurus-plugin-content-blog/2023-06-05-network.md
+++ b/i18n/en/docusaurus-plugin-content-blog/2023-06-05-network.md
@@ -1,6 +1,6 @@
 ---
 slug: 2023-06-05-network
-title: "[Maintainance] June 2, 2023: Network Maintenance on Monday, June 5, 2023"
+title: "(Ended) [Maintainance] June 2, 2023: Network Maintenance on Monday, June 5, 2023"
 tags:
   - maintenance
 authros:

--- a/i18n/en/docusaurus-plugin-content-docs/current/advanced_guides/advanced_guide.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/advanced_guides/advanced_guide.md
@@ -7,6 +7,8 @@ title: "Latest Topics"
 
 ## Reanalysis dataset of public data of human whole genome analysis
 
+5 Jun 2023.
+
 We will share Reanalysed human whole genome analysis data that have been published in public databases as open access data on the NIG supercomputer.
 
 These data were downloaded from public databases for analysis in the Ministry of Education, Culture, Sports, Science and Technology-JAPAN(MEXT)'s Grant-in-Aid for Scientific Research on Innovative Areas "Elucidation of the origin and establishment of the Yaponesians using genome sequences as a core" (Yaponesians genome) and re-analysed on the NIG supercomputer.
@@ -17,8 +19,14 @@ For sample background and conditions of use, refer to the original papers and us
 
 We share files in CRAM format mapped to GRCh38 and files in gVCF format analysed with the GATK4 or Parabricks HaplotypeCaller algorithm.
 
-Pipelines with equivalent analysis content are available at　
-https://github.com/NCGM-genome/WGSpipeline
+You can get a pipeline with equivalent analysis content at https://github.com/NCGM-genome/WGSpipeline
+
+Also, you can get the dataset from the NIG supercomputer in the following way.
+
+ - For all compute nodes in the general analysis section, the datasets are mounted under `/usr/local/shared_data/public-human-genomes/GRCh38/` and can be accessed and used directly from the analysis programmes in the NIG supercomputer .
+    - The personal genome analysis section is currently being prepared.
+- HTTPS: https://ddbj.nig.ac.jp/public/public-human-genomes/GRCh38/ 
+- FTP: ftp.ddbj.nig.ac.jp/public-human-genomes/GRCh38
 
 <table>
 <tr>
@@ -52,6 +60,8 @@ https://github.com/NCGM-genome/WGSpipeline
 
 
 ## Archaea tools(formerly HCPtools)
+
+10 Jan 2023.
 
 In October 2022, the HCPtools software provider launched the brand name 'Bytix' as a brand name for data transfer systems and the product name was changed from 'HCPtools' to 'Archaea tools'.
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/top.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/top.md
@@ -19,6 +19,7 @@ Due to disk space constraints, we do not back up the data in the user home direc
 
 ## Recent News
 
+- [A reanalysis dataset of public data from the Human Whole Genome Analysis has been published by Yosuke Kawai, Deputy Project Manager, NCGM](/advanced_guides/advanced_guide/#reanalysis-dataset-of-public-data-of-human-whole-genome-analysis) (2023.06.05)
 - [Request for data migration of some users due to the start of operation of the new storage system for databases](/en/blog/2023-04-21-data_migration)  (2023.04.21)
 - &#x26A0; [Extended deadline for account renewal application at the end of FY2022](/en/blog/2023-03-23-renewal-date-extended) (2023.03.23)
 - [Signature to the pledge is now an electronic signature by Adobe, instead of a stamp](/en/blog/2023-03-14-adobe_sign) (2023.03.14)


### PR DESCRIPTION
以下3点、修正作業をいたしました。

1．河合先生のヒト全ゲノム解析の公共データの再解析データセットが公開されたことを、トップページの最近のお知らせに追加した。(日・英両方)

<img width="595" alt="image" src="https://github.com/nig-sc/nigsc_homepage2/assets/56281391/ad29b0f2-4eee-475f-a861-fe2552ada082">

2．河合先生のヒト全ゲノム解析の公共データの再解析データセットの、遺伝研スパコンでの入手先URLの部分を、英語ページに追記した。

3．トップページにあるBytix Archaea (旧HCPtools)のリンクの日本語の「旧」を16進数に修正し、トップページから最新のトピックの該当箇所へ、確実に飛ぶようにした。

どうぞよろしくお願いいたします。