### PR TITLE
Edit perdonal genome analysys NBDC

### DIFF
--- a/docs/personal_genome_division/pg_introduction.md
+++ b/docs/personal_genome_division/pg_introduction.md
@@ -8,7 +8,7 @@ title: "概要（個人ゲノム解析区画）"
 遺伝研スパコンでは、個人ゲノムを取り扱うためにセキュリティーレベルを高めた、他のシステムとは独立した個人ゲノム解析区画を提供しています。
 
 
-遺伝研スパコン個人ゲノム解析区画は以下のセキュリティーガイドラインを遵守した[NBDCの機関外サーバです](https://humandbs.biosciencedbc.jp/off-premise-server)。
+遺伝研スパコン個人ゲノム解析区画は以下のセキュリティーガイドラインを遵守した[NBDCのヒトデータ取扱セキュリティーガイドラインに適合したサーバです](https://humandbs.biosciencedbc.jp/off-premise-server)。
 
 - [NBDCヒトデータ共有ガイドライン](https://humandbs.biosciencedbc.jp/guidelines/data-sharing-guidelines)
 - [NBDCヒトデータ取扱セキュリティガイドライン](https://humandbs.biosciencedbc.jp/guidelines)

--- a/i18n/en/docusaurus-plugin-content-docs/current/personal_genome_division/pg_introduction.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/personal_genome_division/pg_introduction.md
@@ -7,7 +7,7 @@ title: "Introduction（The Personal Genome Analysis Section）"
 
 The NIG supercomputer delivers the personal genome analysis section that is independent of other systems and has an a high level of security for handling personal genomes.
 
-The Personal Genome Analysis of the NIG supercomputer is [an NBDC Off-premise-server](https://humandbs.biosciencedbc.jp/en/off-premise-server) that adheres to the following security guidelines.
+The Personal Genome Analysis of the NIG supercomputer is [a server that complies with NBDC Security Guidelines for Human Data](https://humandbs.biosciencedbc.jp/en/off-premise-server) that adheres to the following security guidelines.
 
 
 - [NBDC Guidelines for Human Data Sharing](https://humandbs.biosciencedbc.jp/en/guidelines/data-sharing-guidelines)


### PR DESCRIPTION
個人ゲノム解析区画の「概要」のページで、
「機関外サーバです。」＝＞「NBDCのヒトデータ取扱セキュリティーガイドラインに適合したサーバです。」
に修正いたしました。

どうぞよろしくお願いいたします。