### PR TITLE
Modified Aspera install for Linux '.tar.gz'=>'.sh'

### DIFF
--- a/docs/software/aspera/install_Aspera.md
+++ b/docs/software/aspera/install_Aspera.md
@@ -68,7 +68,7 @@ Linux の場合は上記の手順で
 
 ```
 tar zxvf ibm-aspera-connect_4.1.0.46-linux_x86_64.tar.gz
-bash ibm-aspera-connect_4.1.0.46-linux_x86_64.tar.gz
+bash ibm-aspera-connect_4.1.0.46-linux_x86_64.sh
 ```
 インストーラを実行すると、`$HOME/.aspera/connect/bin`の下に実行ファイルが展開されるのでここにパスを通します。
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/software/aspera/install_Aspera.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/software/aspera/install_Aspera.md
@@ -64,7 +64,7 @@ For Linux, follow the above steps, the file such as `ibm-aspera-connect_4.1.0.46
 
 ```
 tar zxvf ibm-aspera-connect_4.1.0.46-linux_x86_64.tar.gz
-bash ibm-aspera-connect_4.1.0.46-linux_x86_64.tar.gz
+bash ibm-aspera-connect_4.1.0.46-linux_x86_64.sh
 ```
 
 When you run the installer, the executable file will be extracted under `$HOME/.aspera/connect/bin`, so pass the path here.


### PR DESCRIPTION
浅野先生よりご指摘がありました、Linux用のAsperaインストール方法でbashコマンドに渡すファイル名の拡張子を修正いたしました。

.tar.gz => .sh

https://sc.ddbj.nig.ac.jp/software/aspera/install_Aspera 

ーーー
スパコンHPのLinux用のAsperaインストール方法の記述部分ですが、
```
tar zxvf ibm-aspera-connect_4.1.0.46-linux_x86_64.tar.gz
bash ibm-aspera-connect_4.1.0.46-linux_x86_64.tar.gz
```
となっており、bashコマンドに渡すファイル名がtar.gzになってしまっていますが、正しくはshかと思うので
```
tar zxvf ibm-aspera-connect_4.1.0.46-linux_x86_64.tar.gz
bash ibm-aspera-connect_4.1.0.46-linux_x86_64.sh

![image](https://github.com/nig-sc/nigsc_homepage2/assets/56281391/939c4f63-6b5d-4558-b2af-b6d1e86f97c7)


```
ーーー

どうぞよろしくお願いいたします。