### PR TITLE
Fix parallel spelling

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/software/grid_engine/grid_engine.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/software/grid_engine/grid_engine.md
@@ -32,7 +32,7 @@ The following four types of jobs are mainly used by Grid Engine.
     - To use the supercomputer interactively.
 - [Batch Jobs (batch job)](/software/grid_engine/batch_jobs)
     - To run a small number of programs that use only one CPU core
-- [Pallalel Jobs (parallel job)](/software/grid_engine/parallel_jobs)
+- [Parallel Jobs (parallel job)](/software/grid_engine/parallel_jobs)
     - To run a small number of programs that use multiple CPU cores at the same time
 - [Array Jobs (array job)](/software/grid_engine/array_jobs)
     - To run a large number of batch jobs or parallel jobs sequentially

--- a/i18n/en/docusaurus-plugin-content-docs/current/software/grid_engine/parallel_jobs/parallel_jobs.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/software/grid_engine/parallel_jobs/parallel_jobs.md
@@ -1,6 +1,6 @@
 ---
 id: parallel_jobs
-title: Pallalel Jobs (parallel job)
+title: Parallel Jobs (parallel job)
 ---
 
 When you run a small number of programs that use multiple CPU cores and run for a long time, run them as parallel jobs. (When you execute many jobs, use the array job of parallel jobs.)


### PR DESCRIPTION
Parallel was misspelt as "pallalel" in two places.