### PR TITLE
Add usage_plan_table_2024_v1.0.0

### DIFF
--- a/docs/application/resource_extension.md
+++ b/docs/application/resource_extension.md
@@ -25,6 +25,8 @@ title: "利用計画表の提出"
 
 <a href="https://github.com/nig-sc/usage_plan_table/blob/main/usage_plan_table2023_v1.2.1.xlsx"><ul><li><font size="+1.5">利用計画表(2023年度版)</font></li></ul></a>
 
+<a href="https://github.com/nig-sc/usage_plan_table/blob/main/usage_plan_table2024_v1.0.0.xlsx"><ul><li><font size="+1.5">利用計画表(2024年度版)</font></li></ul></a>
+
 <p>&#x26A0;現在、大規模利用ユーザおよび一般解析区画大規模ユーザのアカウントの新規登録の受付を停止しております。詳細は<a href="https://sc.ddbj.nig.ac.jp/blog/2022-05-13-suspension-of-applications">こちらのお知らせをご参照ください</a>。</p>
 </td>
 </tr>

--- a/i18n/en/docusaurus-plugin-content-docs/current/application/resource_extension.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/application/resource_extension.md
@@ -24,6 +24,8 @@ Click here.
 
 <a href="https://github.com/nig-sc/usage_plan_table/blob/main/usage_plan_table2023_v1.2.1.xlsx"><ul><li><font size="+1.5">the usage plan table(2023)</font></li></ul></a>
 
+<a href="https://github.com/nig-sc/usage_plan_table/blob/main/usage_plan_table2024_v1.0.0.xlsx"><ul><li><font size="+1.5">the usage plan table(2024)</font></li></ul></a>
+
 <p>&#x26A0; Currently, we are not accepting application for new use of the personal genomic analysis division and large-scale storage on the general analysis division. For more information, <a href="https://sc.ddbj.nig.ac.jp/en/blog/2022-05-13-suspension-of-applications">refer to this announcement page</a>.</p>
 </td>
 </tr>


### PR DESCRIPTION
「利用計画表の利用」のページに、2024年の利用計画表を追加いたしました。
ホームページのリンク(赤丸部分)をクリックすると、以下に飛びます。
https://github.com/nig-sc/usage_plan_table/blob/main/usage_plan_table2024_v1.0.0.xlsx


<img width="788" alt="スクリーンショット 2024-01-25 140917" src="https://github.com/nig-sc/nigsc_homepage2/assets/56281391/d2e79d2e-b001-48ec-a9bc-87de1e1e91ad">」


<img width="719" alt="スクリーンショット 2024-01-25 141317" src="https://github.com/nig-sc/nigsc_homepage2/assets/56281391/677998b4-4e72-4b14-ad1e-0d43455928fe">


どうぞよろしくお願いいたします。