### PR TITLE
Modifed renewal.md (deleted the sentence about the extending renewal …

### DIFF
--- a/docs/application/renewal.md
+++ b/docs/application/renewal.md
@@ -3,18 +3,10 @@ id: renewal
 title: "年度末アカウント継続申請"
 ---
 
-年度末アカウント継続申請の期日を以下のように延長します。延長についての詳細は、[お知らせをご参照ください](/blog/2023-03-23-renewal-date-extended)。対処方法につきましては[FAQにまとめましたので、そちらをご覧ください](/faq/faq_renewal)。
-
-
-継続申請期限: 2023年3月31日(金)　→　2023年5月7日(日)　に延長
 
 ## 申請時期
 
 例年1月1日から3月31日まで受け付けます。
-
-## 申請方法
-
-[&#x1f517;<u>アカウント申請システムのマイページにログインして、</u>](https://sc-account.ddbj.nig.ac.jp/auth/realms/master/protocol/openid-connect/auth?client_id=sc&scope=openid&response_type=code&redirect_uri=https%3A%2F%2Fsc-account.ddbj.nig.ac.jp%2Fapi%2Fauth%2Fcallback%2Fkeycloak&state=6ygcuJParJ3i8ZlDMnKicXvW3MxkWp4t06IBKOVAbIE&code_challenge=hDLDfyOsqUc58Z-xzzz1g5ybLDycWgY7UV8e-qu1jd8&code_challenge_method=S256) 申請を行ってください。
 
 
 ## 申請手順
@@ -22,8 +14,6 @@ title: "年度末アカウント継続申請"
 [&#x1f517;<u>アカウント申請システムのマイページにログイン</u>](https://sc-account.ddbj.nig.ac.jp/auth/realms/master/protocol/openid-connect/auth?client_id=sc&scope=openid&response_type=code&redirect_uri=https%3A%2F%2Fsc-account.ddbj.nig.ac.jp%2Fapi%2Fauth%2Fcallback%2Fkeycloak&state=6ygcuJParJ3i8ZlDMnKicXvW3MxkWp4t06IBKOVAbIE&code_challenge=hDLDfyOsqUc58Z-xzzz1g5ybLDycWgY7UV8e-qu1jd8&code_challenge_method=S256)＞アカウント申請＞利用継続申請
 
 
-アカウント申請システムのマイページへのログイン方法は、[<u>「アカウント情報の変更」ページをご参照ください。</u>](/application/change_account_info)
-
-
-その他よくあるご質問は、[<u>FAQをご参照ください</u>](/faq/faq_renewal/)。
+- アカウント申請システムのマイページへのログイン方法は、[<u>「アカウント情報の変更」ページをご参照ください。</u>](/application/change_account_info)
+- その他よくあるご質問は、[<u>FAQをご参照ください</u>](/faq/faq_renewal/)。
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/application/renewal.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/application/renewal.md
@@ -3,9 +3,6 @@ id: renewal
 title: "Applying for a renewal of your account of the end of the fiscal year"
 ---
 
-We decided to extend the end-of-year(FY2022) renewal deadline as follows. For more information about the extension, [see news](/blog/2023-03-23-renewal-date-extended).　For information on how to deal with this, [please refer to FAQ](/faq/faq_renewal).
-
-Deadline for renewal applications: 31 March 2023 (Friday) → extended to 7 May 2023 (Sunday)
 
 ## When to apply
 
@@ -15,8 +12,5 @@ Applications are accepted from 1 January to 31 March every year.
 
 [&#x1f517;<u>Login to your account page</u>](https://sc-account.ddbj.nig.ac.jp/auth/realms/master/protocol/openid-connect/auth?client_id=sc&scope=openid&response_type=code&redirect_uri=https%3A%2F%2Fsc-account.ddbj.nig.ac.jp%2Fapi%2Fauth%2Fcallback%2Fkeycloak&state=6ygcuJParJ3i8ZlDMnKicXvW3MxkWp4t06IBKOVAbIE&code_challenge=hDLDfyOsqUc58Z-xzzz1g5ybLDycWgY7UV8e-qu1jd8&code_challenge_method=S256) > Application > Continuation
 
-For details on how to login to the user account page, [<u>refer to the 'Change of application details' division of the 'Account Application and Change of Application Details' page.</u>](/application/registration#change-of-application-details)
-
-![](Keycload.png)
-
-For other FAQ, [<u>see FAQ</u>](/faq/faq_renewal/).
+- For details on how to login to the user account page, [<u>refer to the 'Change of application details' division of the 'Account Application and Change of Application Details' page.</u>](/application/registration#change-of-application-details)
+- For other FAQ, [<u>see FAQ</u>](/faq/faq_renewal/).


### PR DESCRIPTION
年度末アカウント申請のページで、以下2点修正いたしました。

1．日・英の両ページで、下図の赤丸部分を削除した。
2．日本語のページのみ、下図の紫丸部分を削除した。「申請方法」と「申請手順」の記載内容が重複しているため。
英語ページは、もとから「申請時期」と「申請手順」しか掲載されていないので修正不要。

<img width="830" alt="image" src="https://github.com/nig-sc/nigsc_homepage2/assets/56281391/735e1610-fd0f-4b99-90a8-e9f4bd293903">

どうぞよろしくお願いいたします。