### PR TITLE
Modify /software/Apptainer.md CentOS 7.5 => 7.9

### DIFF
--- a/docs/guides/top.md
+++ b/docs/guides/top.md
@@ -21,7 +21,6 @@ sidebar_label: トップページ
 ## 重要なお知らせ
 
 - [(終了) 2024 年 3 月 9 日(土) SINET6 の機器メンテナンス作業により通信断が発生します](/blog/2024-03-09-network) (2024.03.08)
-- &#x26a0; [(終了) 12 月 27 日～1 月 9 日 年末年始に伴いアカウント登録システムを停止します](/blog/2023-12-27-account_registration_system_outage_NewYearsHoliday) (2023.12.27)
 - [(終了) 11 月 24 日 - 11 月 30 日に定期メンテナンスを行います ← 作業内容について更新しました](/blog/2023-11-24-scheduled-maintenance)　(2023.12.01)
     - [OS 移行に伴う FAQ のページを作成しました](/faq/faq_os_migration)＼&#x1f195;／
 - [ISMS 認証(ISO27001)を取得しました](/guides/ISMS_Certificate) (2023.11.22)

--- a/docs/software/Apptainer/Apptainer.md
+++ b/docs/software/Apptainer/Apptainer.md
@@ -9,7 +9,7 @@ title: "Apptainer (Singularity)の使い方"
 
 遺伝研スパコンでは様々な解析ソフトウェアをユーザー権限でインストール出来るようにするため Apptainer (Sigularity) コンテナが利用可能です。
 
-Apptainer (Sigularity) を使うことによって例えば遺伝研スパコン(CentOS7.5)の上で、Ubuntu Linux の apt-get 等でインストールした解析ソフトウェアを動作させることが可能になります。
+Apptainer (Sigularity) を使うことによって例えば遺伝研スパコン(CentOS7.9)の上で、Ubuntu Linux の apt-get 等でインストールした解析ソフトウェアを動作させることが可能になります。
 
 
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/top.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/top.md
@@ -20,7 +20,6 @@ Due to disk space constraints, we do not back up the data in the user home direc
 ## Featured News
 
 - [(Ended) March 9, 2024: Communication breakdowns occur due to network device maintenance](/blog/2024-03-09-network) (2024.03.08)
-- &#x26a0; [(Ended) December 27, 2023 - January 9, 2024, the account registration system will be suspended due to the year-end and New Year's holidays.](/blog/2023-12-27-account_registration_system_outage_NewYearsHoliday) (2023.12.27)
 - [(Ended) Scheduled maintenance from 24 to 30 November ← Updated work description](/blog/2023-11-24-scheduled-maintenance) (2023.12.01)
     - [FAQ page for OS migration has been created.](/faq/faq_os_migration) ＼&#x1f195;／
 - [Certified to ISMS (ISO 27001:2013)](/guides/ISMS_Certificate) (2023.11.22)

--- a/i18n/en/docusaurus-plugin-content-docs/current/software/Apptainer/Apptainer.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/software/Apptainer/Apptainer.md
@@ -10,7 +10,7 @@ title: "Apptainer (Singularity)"
 
 Apptainer (Sigularity) containers are available on the NIG supercomputer to install various analysis software with user permission.
 
-By using Apptainer (Sigularity), for example, it is possible to run analysis software installed by Ubuntu Linux apt-get etc. on the NIG supercomputer (CentOS 7.5).
+By using Apptainer (Sigularity), for example, it is possible to run analysis software installed by Ubuntu Linux apt-get etc. on the NIG supercomputer (CentOS 7.9).
 
 
 ## Reference

--- a/i18n/en/docusaurus-plugin-content-docs/current/software/Singularity.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/software/Singularity.md
@@ -7,7 +7,7 @@ title: "Singularity"
 
 Singularity containers are available on the NIG supercomputer to install various analysis software with user permission.
 
-By using Singularity, for example, it is possible to run analysis software installed by Ubuntu Linux apt-get etc. on the NIG supercomputer (CentOS 7.5).
+By using Singularity, for example, it is possible to run analysis software installed by Ubuntu Linux apt-get etc. on the NIG supercomputer (CentOS 7.9).
 
 
 ## Reference


### PR DESCRIPTION
以下2点、修正いたしました。

1．スパコンホームページ内で、CentOS7.9ではなく、CentOS7.5と記載があるページを、すべてCentOS7.9に修正した。
2．重要なお知らせの上から２つ目を、重要なお知らせから削除した。

どうぞよろしくお願いいたします。