### PR TITLE
Modify Forticlient website URL

### DIFF
--- a/docs/faq/faq_login_personal.md
+++ b/docs/faq/faq_login_personal.md
@@ -75,13 +75,13 @@ Host *
 
 以下のURLをクリックして、ForiClientの公式サイトのページにアクセスしたら、表示されたページの下の方にある「FortiClient VPN」から、Windows用またはMac用のFortiClient VPNクライアントソフトウェアをダウンロードします。下図の①、②の順にクリックすると、ダウンロードできます。
 
-- FortiClient公式サイト: [https://www.forticlient.com/downloads](https://www.forticlient.com/downloads)
-
-＜Macの場合＞
-![figure](VPN_MAC_install_1_701_2.png)
+- FortiClient公式サイト: [https://www.fortinet.com/support/product-downloads](https://www.fortinet.com/support/product-downloads)
 
 ＜Windowsの場合＞
 ![figure](VPNwin_2_701_2.png)
+
+＜Macの場合＞
+![figure](VPN_MAC_install_1_701_2.png)
 
 
 

--- a/docs/personal_genome_division/pg_login_ssl-vpn_install_mac.md
+++ b/docs/personal_genome_division/pg_login_ssl-vpn_install_mac.md
@@ -7,7 +7,7 @@ title: "SSL-VPNクライアントソフトウェアのインストール(Macの�
 ## SSL-VPN クライアントソフトウェア「FortiClient」のダウンロード方法
 
 1. 以下のURLをクリックして、ForiClientの公式サイトのページにアクセスします。いくつかソフトウェアが表示されますが、そのうちの「FortiClient VPN only」をダウンロードしてください。
-	- FortiClient公式サイト: [https://www.forticlient.com/downloads](https://www.forticlient.com/downloads)
+	- FortiClient公式サイト: [https://www.fortinet.com/support/product-downloads](https://www.fortinet.com/support/product-downloads)
 
 ![figure](VPN_MAC_install_1_701_1.png)
 

--- a/docs/personal_genome_division/pg_login_ssl-vpn_install_win.md
+++ b/docs/personal_genome_division/pg_login_ssl-vpn_install_win.md
@@ -7,7 +7,7 @@ title: "SSL-VPNクライアントソフトウェアのインストール(Windows
 ## SSL-VPN クライアントソフトウェア「FortiClient」のダウンロード方法
 
 1. 以下のURLをクリックして、ForiClientの公式サイトのページにアクセスします。いくつかソフトウェアが表示されますが、そのうちの「FortiClient VPN only」をダウンロードしてください。
-	- FortiClient公式サイト: [https://www.forticlient.com/downloads](https://www.forticlient.com/downloads)
+	- FortiClient公式サイト: [https://www.fortinet.com/support/product-downloads](https://www.fortinet.com/support/product-downloads)
 
 ![figure](VPN_MAC_install_1_701_1.png)
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/faq/faq_login_personal.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/faq/faq_login_personal.md
@@ -80,7 +80,7 @@ For more information, click the link below.
 
 Click on the URL below to access the official ForiClient website page, then download the FortiClient VPN client software for Windows or Mac from 'FortiClient VPN' at the bottom of the displayed page. Click on ① and ② in the diagram below to download the software.
 
-- FortiClient official website:[https://www.forticlient.com/downloads](https://www.forticlient.com/downloads)
+- FortiClient official website:[https://www.fortinet.com/support/product-downloads](https://www.fortinet.com/support/product-downloads)
 
 
 ＜Windows＞

--- a/i18n/en/docusaurus-plugin-content-docs/current/personal_genome_division/pg_login_ssl-vpn_install_mac.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/personal_genome_division/pg_login_ssl-vpn_install_mac.md
@@ -8,7 +8,7 @@ title: "Installing the SSL-VPN Client software FortiClient VPN(MacOS)"
 
 Click on the following URL to access the official ForiClient website page. You will see several software, of which download 'FortiClient VPN only'.
 
-- FortiClient official website: [https://www.forticlient.com/downloads](https://www.forticlient.com/downloads)
+- FortiClient official website: [https://www.fortinet.com/support/product-downloads](https://www.fortinet.com/support/product-downloads)
 
 ![figure](VPN_MAC_install_1_701_1.png)
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/personal_genome_division/pg_login_ssl-vpn_install_win.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/personal_genome_division/pg_login_ssl-vpn_install_win.md
@@ -8,7 +8,7 @@ title: "Installing the SSL-VPN Client software FortiClient VPN(Windows)"
 
 Click on the following URL to access the official ForiClient website page. You will see several software, of which download 'FortiClient VPN only'.
 
-- FortiClient official website: [https://www.forticlient.com/downloads](https://www.forticlient.com/downloads)
+- FortiClient official website: [https://www.fortinet.com/support/product-downloads](https://www.fortinet.com/support/product-downloads)
 
 ![figure](VPN_MAC_install_1_701_1.png)
 


### PR DESCRIPTION
個人ゲノム解析区画で、SSL-VPNクライアントソフトウェア FortiClient のダウンロードURLを修正いたしました。

修正前：https://www.fortinet.com/downloads　← FortiClientのトップページのURL
修正後：https://www.fortinet.com/support/product-downloads　←FortiClient VPN ダウンロードサイトのURL

どうぞよろしくお願いいたします。