### PR TITLE
Edit hardware.md Fat node' type

### DIFF
--- a/docs/guides/hardware.md
+++ b/docs/guides/hardware.md
@@ -285,7 +285,7 @@ FAT 計算ノード１ノード（HPE Superdome Flex 2 筐体）当たりのス�
 
 | 構成要素 | 型番                                                    | 員数 | ノードあたりの性能など               |
 |----------|---------------------------------------------------------|------|--------------------------------------|
-| CPU      | Intel Xeon Gold 6148 (20 cores) Base 2.4GHz, Max 3.7GHz |   16 | 合計 288 コア                         |
+| CPU      | Intel Xeon Gold 6154 (18 cores) Base 3.0GHz, Max 3.7GHz |   16 | 合計 288 コア                         |
 | Memory   | 32GB DDR4-2666                                          |  192 | 合計 12,288GB (CPU コアあたり 47.2GB) |
 | Storage  | 1.2TB SAS HDD                                           |    4 | 2.4TB (RAID1)                        |
 | Network  | InfiniBand 4xEDR                                        |    1 | 100Gbps                              |

--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/hardware.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/hardware.md
@@ -271,7 +271,7 @@ HPE Superdome Flex
 	
 | component |model number                                             | number of computation | performance par node, etc            |
 |-----------|---------------------------------------------------------|-----------------------|--------------------------------------|
-| CPU       | Intel Xeon Gold 6148 (20 cores) Base 2.4GHz, Max 3.7GHz |                    16 | Total 288 core                       |
+| CPU       | Intel Xeon Gold 6154 (18 cores) Base 3.0GHz, Max 3.7GHz |                    16 | Total 288 core                       |
 | Memory    | 32GB DDR4-2666                                          |                   192 | Total 12,288GB (47.2GB per CPU core) |
 | Storage   | 1.2TB SAS HDD                                           |                     4 | 2.4TB (RAID1)                        |
 | Network   | InfiniBand 4xEDR                                        |                     1 | 100Gbps                              |


### PR DESCRIPTION
奥田さんより、ご依頼で、CPUの型番を「Intel Xeon Gold 6154 (18 cores) Base 3.0GHz」に修正いたしました。

![image](https://github.com/nig-sc/nigsc_homepage2/assets/56281391/dfdd561c-9306-4818-aa64-a4784919a928)

ーーー
@明子 FatノードのCPUについですが、https://sc.ddbj.nig.ac.jp/guides/hardware と https://sc.ddbj.nig.ac.jp/guides/overview で型番が異なっており、芦澤さんに確認してもらったところ Intel Xeon Gold 6154 (18 cores) が正しいとのことです。ハードウェアのページの修正をお願いします。
ーーー