### PR TITLE
Restore_usage_plan_table2024_100-110_akats240422

### DIFF
--- a/docs/application/resource_extension.md
+++ b/docs/application/resource_extension.md
@@ -25,7 +25,7 @@ title: "利用計画表の提出"
 
 <a href="https://github.com/nig-sc/usage_plan_table/blob/main/usage_plan_table2023_v1.2.1.xlsx"><ul><li><font size="+1.5">利用計画表(2023年度版)</font></li></ul></a>
 
-<a href="https://github.com/nig-sc/usage_plan_table/blob/main/usage_plan_table2024_v1.0.0.xlsx"><ul><li><font size="+1.5">利用計画表(2024年度版)</font></li></ul></a>
+<a href="https://github.com/nig-sc/usage_plan_table/blob/main/usage_plan_table2024_v1.1.0.xlsx"><ul><li><font size="+1.5">利用計画表(2024年度版)</font></li></ul></a>
 
 <p>&#x26A0;現在、大規模利用ユーザおよび一般解析区画大規模ユーザのアカウントの新規登録の受付を停止しております。詳細は<a href="https://sc.ddbj.nig.ac.jp/blog/2022-05-13-suspension-of-applications">こちらのお知らせをご参照ください</a>。</p>
 </td>

--- a/i18n/en/docusaurus-plugin-content-docs/current/application/resource_extension.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/application/resource_extension.md
@@ -24,7 +24,7 @@ Click here.
 
 <a href="https://github.com/nig-sc/usage_plan_table/blob/main/usage_plan_table2023_v1.2.1.xlsx"><ul><li><font size="+1.5">the usage plan table(2023)</font></li></ul></a>
 
-<a href="https://github.com/nig-sc/usage_plan_table/blob/main/usage_plan_table2024_v1.0.0.xlsx"><ul><li><font size="+1.5">the usage plan table(2024)</font></li></ul></a>
+<a href="https://github.com/nig-sc/usage_plan_table/blob/main/usage_plan_table2024_v1.1.0.xlsx"><ul><li><font size="+1.5">the usage plan table(2024)</font></li></ul></a>
 
 <p>&#x26A0; Currently, we are not accepting application for new use of the personal genomic analysis division and large-scale storage on the general analysis division. For more information, <a href="https://sc.ddbj.nig.ac.jp/en/blog/2022-05-13-suspension-of-applications">refer to this announcement page</a>.</p>
 </td>


### PR DESCRIPTION
利用計画表2024の文書管理番号C-42=>C-49にを修正したため、githubの利用計画表を差し替えて、ダウンロードURLを修正いたしました。
https://github.com/nig-sc/usage_plan_table/blob/main/usage_plan_table2024_v1.1.0.xlsx

どうぞよろしくお願いいたします。