### PR TITLE
Edit software_update_info.md guacamole date 2015 to 2021

### DIFF
--- a/docs/software/software_update_info.md
+++ b/docs/software/software_update_info.md
@@ -416,7 +416,7 @@ title: ソフトウェア更新情報
 </tr>
 
 <tr>
-<td align="center">2015.05.14</td>
+<td align="center">2021.05.14</td>
 <td align="center">利用不可</td>
 <td align="center">1.4.0</td>
 <td align="center">〇</td>

--- a/i18n/en/docusaurus-plugin-content-blog/2024-07-01-news_renewal-date-extended.md
+++ b/i18n/en/docusaurus-plugin-content-blog/2024-07-01-news_renewal-date-extended.md
@@ -1,6 +1,6 @@
 ---
-slug: (Ended) 2024-07-01-news_renewal-date-extended
-title: "July 1, 2024:  Extended deadline for account renewal application at the end of FY2023"
+slug: 2024-07-01-news_renewal-date-extended
+title: "(Ended) July 1, 2024:  Extended deadline for account renewal application at the end of FY2023"
 tags:
   - news
 authros:

--- a/i18n/en/docusaurus-plugin-content-docs/current/software/software_update_info.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/software/software_update_info.md
@@ -416,7 +416,7 @@ Version<br />
 </tr>
 
 <tr>
-<td align="center">2015.05.14</td>
+<td align="center">2021.05.14</td>
 <td align="center">unavailable</td>
 <td align="center">1.4.0</td>
 <td align="center">〇</td>


### PR DESCRIPTION
ソフトウェア更新情報のGuadamoleの更新日を「2015.05.14」=>「2021.・・・」に修正いたしました。

![image](https://github.com/user-attachments/assets/5ef50769-5592-4a4c-93e6-a12d502faf6f)


どうぞよろしくお願いいたします。