### PR TITLE
Rename blog title 20250222 Slurm Resolved to Restored

### DIFF
--- a/blog/2025-05-22-Slurm_ga_maintenance.md
+++ b/blog/2025-05-22-Slurm_ga_maintenance.md
@@ -1,6 +1,6 @@
 ---
 slug: 2025-05-22-Slurm_ga_maintenance
-title: "(終了) 2025年5月22日(木) 一般解析区画のslurm障害発生"
+title: "(復旧) 2025年5月22日(木) 一般解析区画のslurm障害発生"
 tags:
   - maintenance
 date: 2025-05-22

--- a/docs/guides/010_top_page/010_top_page.md
+++ b/docs/guides/010_top_page/010_top_page.md
@@ -117,7 +117,7 @@ WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!
 
 ## 重要なお知らせ {#featured-news}
 
-- [(終了) 2025年5月22日(木) 一般解析区画のslurm障害発生のお知らせ](/blog/2025-05-22-Slurm_ga_maintenance) (2025.05.22) ＼ &#x1F195; ／
+- [(復旧) 2025年5月22日(木) 一般解析区画のslurm障害発生のお知らせ](/blog/2025-05-22-Slurm_ga_maintenance) (2025.05.22) ＼ &#x1F195; ／
 - [2025年5月24日(水) SINET6への切替作業による通信断のお知らせ](/blog/2025-05-24-network) (2025.04.10)
 - [2025年4月7日(月)停電の発生について](/blog/2025-04-07-power-outage) (2025.04.07)
 - [遺伝研スパコンからの重要なお知らせ : 2024年第3期(12～3月)](/blog/2025-02-10-important_notice_2024_Dec-2025_Mar) (2025.02.10) 

--- a/i18n/en/docusaurus-plugin-content-blog/2025-05-22-Slurm_ga_maintenance.md
+++ b/i18n/en/docusaurus-plugin-content-blog/2025-05-22-Slurm_ga_maintenance.md
@@ -1,6 +1,6 @@
 ---
 slug: 2025-05-22-Slurm_ga_maintenance
-title: "(Resolved) [Outage] May 22, 2025:  Slurm Outage in General Analysis Division on Thursday, May 22, 2025"
+title: "(Restored) [Outage] May 22, 2025:  Slurm Outage in General Analysis Division on Thursday, May 22, 2025"
 tags:
   - maintenance
 date: 2025-05-22

--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/010_top_page/010_top_page.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/010_top_page/010_top_page.md
@@ -113,7 +113,7 @@ Due to limited disk capacity, the research institute does not back up data in us
 
 ## Featured News {#featured-news}
 
-- [(Resolved) [Outage] Slurm Outage in General Analysis Division on Thursday, May 22, 2025](/blog/2025-05-22-Slurm_ga_maintenance) (May 22, 2025) ＼ &#x1F195; ／
+- [(Restored) [Outage] Slurm Outage in General Analysis Division on Thursday, May 22, 2025](/blog/2025-05-22-Slurm_ga_maintenance) (May 22, 2025) ＼ &#x1F195; ／
 - [Network Maintenance due to Switchover to SINET6 on Wednesday, May 24, 2025](/blog/2025-05-24-network) (April 10, 2025)
 - [Power Outage on April 7, 2025](/blog/2025-04-07-power-outage) (April 7, 2025)
 - [Important Notices from the NIG Supercomputer: Third Term of 2024 (December–March)](/blog/2025-02-10-important_notice_2024_Dec-2025_Mar) (February 10, 2025) 


### PR DESCRIPTION
お知らせのタイトルと、「(終了) 2025年5月22日(木) 一般解析区画のslurm障害発生」→「(復旧)・・・」に修正いたしました。


<img width="562" alt="image" src="https://github.com/user-attachments/assets/abcb95ac-6a6e-481f-9287-230f2186106a" />


<img width="906" alt="image" src="https://github.com/user-attachments/assets/3b76d9b6-a047-4d61-9bb3-fbcae03a72d6" />


どうぞよろしくお願いいたします。